### PR TITLE
fix for ubuntu 16.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,6 @@ cd  $Drvfoulder
 echo "EXTRA_CFLAGS += -Wno-error=date-time" > /tmp/tmp-makefile
 cat Makefile >> /tmp/tmp-makefile
 cp /tmp/tmp-makefile Makefile
-cat Makefile
 
 ################################################################################
 #			Edit [2016-05-03]: On upgrading to Ubuntu 16.04, with its 4.4 kernel,

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Auto install for 8192cu
 # September, 1 2010 v1.0.0, willisTang
-# 
+#
 # Add make_drv to select chip type
 # Novembor, 21 2011 v1.1.0, Jeff Hung
 ################################################################################
@@ -12,7 +12,7 @@ echo "Novembor, 21 2011 v1.1.0"
 echo "##################################################"
 
 ################################################################################
-#			Decompress the driver source tal ball
+#			Decompress the driver source tar ball
 ################################################################################
 cd driver
 Drvfoulder=`ls |grep .tar.gz`
@@ -23,6 +23,49 @@ tar zxvf $Drvfoulder
 Drvfoulder=`ls |grep -iv '.tar.gz'`
 echo "$Drvfoulder"
 cd  $Drvfoulder
+
+################################################################################
+#			Recent GCCs error if the build is non-reproducible because of using the date or time macros. In the driver directory, add the following to the Makefile:
+#			EXTRA_CFLAGS += -Wno-error=date-time
+#
+#			http://feiraspromove.com.br/posts/2015-12-08-Alfa-awus036ac.html
+################################################################################
+echo "EXTRA_CFLAGS += -Wno-error=date-time" > /tmp/tmp-makefile
+cat Makefile >> /tmp/tmp-makefile
+cp /tmp/tmp-makefile Makefile
+cat Makefile
+
+################################################################################
+#			Edit [2016-05-03]: On upgrading to Ubuntu 16.04, with its 4.4 kernel,
+#			there was an additional change. In the driver directory, in rtw_debug.h,
+#			there are a couple errors because seq_printf is void, not int.
+#			So, there are two places where you’ll need to get rid of the if surrounding
+#			use of _seqdump, which is on lines 232 and 242.
+#
+# 		http://feiraspromove.com.br/posts/2015-12-08-Alfa-awus036ac.html
+################################################################################
+affectedKernel="4.4"
+IN=`uname -r`
+arrIN=(${IN//./ })
+KernelVersion=""
+for i in "${!arrIN[@]}"
+do
+   :
+   # do whatever on $i
+   if (($i > 0)); then
+   	KernelVersion="$KernelVersion."
+   fi
+   KernelVersion="$KernelVersion${arrIN[$i]}"
+
+   if (($i == 1)); then
+   	break
+   fi
+done
+
+if [ "$KernelVersion" = "$affectedKernel" ]; then
+	sed -i '232s/.*/ _seqdump\(sel, fmt, ##arg\)\; \\/' include/rtw_debug.h
+	sed -i '242s/.*/_seqdump\(sel, fmt, ##arg\)\; \\/' include/rtw_debug.h
+fi
 
 ################################################################################
 #			If makd_drv exixt, execute it to select chip type


### PR DESCRIPTION
As I was trying to install in ubuntu 16.04 64-bit, I encountered 2 errors which is related to (1)problem no. 2 and (2)the latest update in [Just Joshing article](http://feiraspromove.com.br/posts/2015-12-08-Alfa-awus036ac.html):

```
2.) Recent GCCs error if the build is non-reproducible because of using the date or time macros. In the driver directory, add the following to the Makefile:

EXTRA_CFLAGS += -Wno-error=date-time
```

```
Edit [2016-05-03]: On upgrading to Ubuntu 16.04, with its 4.4 kernel, there was an additional change. In the driver directory, in rtw_debug.h, there are a couple errors because seq_printf is void, not int. So, there are two places where you’ll need to get rid of the if surrounding use of _seqdump, which is on lines 232 and 242.
```
